### PR TITLE
Create icon folder if not exists

### DIFF
--- a/appimage-desktop-entry.sh
+++ b/appimage-desktop-entry.sh
@@ -35,8 +35,10 @@ read SELECTED_INDEX
 
 ICON_SRC=${FILENAMES[$(expr $SELECTED_INDEX - 1)]}
 ICON_EXT="${ICON_SRC##*.}"
-ICON_DST="${HOME}/.local/share/icons/$APP_NAME.$ICON_EXT"
-cp "$ICON_SRC" "$ICON_DST"
+ICON_FOLDER="${HOME}/.local/share/icons"
+ICON_DST="${ICON_FOLDER}/$APP_NAME.$ICON_EXT"             
+mkdir -p "${ICON_FOLDER}"
+cp "$ICON_SRC" "$ICON_DST" 
 
 DESKTOP_ENTRY_PATH="${HOME}/.local/share/applications/$APP_NAME.desktop"
 


### PR DESCRIPTION
Added `mkdir -p` for create icon folder if it doesn't exist.
On Ubuntu 22.04 script return an error about non-existing folder.